### PR TITLE
Remove duplicate DB init in InicioActivity

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -58,6 +58,8 @@ dependencies {
     implementation libs.activity
     implementation libs.constraintlayout
     testImplementation libs.junit
+    testImplementation 'org.robolectric:robolectric:4.11.1'
+    testImplementation 'androidx.test:core:1.5.0'
     androidTestImplementation libs.ext.junit
     androidTestImplementation libs.espresso.core
 }

--- a/app/src/main/java/com/example/wikifountains/activities/InicioActivity.java
+++ b/app/src/main/java/com/example/wikifountains/activities/InicioActivity.java
@@ -11,7 +11,6 @@ import android.view.MenuItem;
 
 
 import com.example.wikifountains.R;
-import com.example.wikifountains.data.BBDDInitializer;
 
 
 public class InicioActivity extends BaseActivity {
@@ -22,8 +21,7 @@ public class InicioActivity extends BaseActivity {
         super.onCreate(savedInstanceState);
 
         setContentViewWithDrawer(R.layout.activity_inicio);
-        // Inicializar base de datos y cargar fuentes
-        BBDDInitializer.initialize(this);
+        // La base de datos se inicializa desde AppDatabase.getInstance()
         // Cargar orden de preferencia
         SharedPreferences preferences = getSharedPreferences("MyPrefs", Context.MODE_PRIVATE);
         preferences.getBoolean("ordenar_fuentes", false);

--- a/app/src/test/java/com/example/wikifountains/DatabaseInitializationTest.java
+++ b/app/src/test/java/com/example/wikifountains/DatabaseInitializationTest.java
@@ -1,0 +1,40 @@
+package com.example.wikifountains;
+
+import android.content.Context;
+
+import androidx.test.core.app.ApplicationProvider;
+
+import com.example.wikifountains.data.AppDatabase;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.robolectric.RobolectricTestRunner;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.*;
+
+@RunWith(RobolectricTestRunner.class)
+public class DatabaseInitializationTest {
+    private Context context;
+
+    @Before
+    public void setUp() {
+        context = ApplicationProvider.getApplicationContext();
+        context.deleteDatabase("fuentes_database");
+    }
+
+    @Test
+    public void initialDataLoadedWithoutDuplicates() throws Exception {
+        AppDatabase db1 = AppDatabase.getInstance(context);
+        // Esperar a que se complete la carga inicial
+        Thread.sleep(1000);
+        int firstCount = db1.fuenteDao().countFuentes();
+
+        AppDatabase db2 = AppDatabase.getInstance(context);
+        Thread.sleep(500);
+        int secondCount = db2.fuenteDao().countFuentes();
+
+        assertEquals(firstCount, secondCount);
+        assertEquals(26, firstCount);
+    }
+}


### PR DESCRIPTION
## Summary
- remove `BBDDInitializer.initialize` call from `InicioActivity`
- add Robolectric-based test to ensure database loads only once
- add test dependencies

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_684df26761208323aa1812c05ae455bb